### PR TITLE
fix: Don't generate a build on README.md edits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+  paths-ignore:
+      - '**/README.md'
 env:
     IMAGE_NAME: ubuntu
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
That way we're not kicking off unnecessary builds