### PR TITLE
feat: add release and conventional commit actions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,14 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: main
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: webiny/action-conventional-commits@v1.1.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action


### PR DESCRIPTION
This will lint us into doing conventional commits per PR, and will open a new PR with all incoming changes. When we're ready to "release" we merge the release PR and it does the rest.

This will keep updating the open PR on new merges, however I think once we get used to it we should set it to fire off monthly for a roll up of the release notes.